### PR TITLE
fix: remove colors from log

### DIFF
--- a/app/bot/main.go
+++ b/app/bot/main.go
@@ -19,6 +19,7 @@ var (
 
 func init() {
 	flag.Parse()
+	yal.Log.Colors = false;
 }
 
 func SetLogger(value string) {


### PR DESCRIPTION
sets the yal.Log.Colors to false so that the logs are not filled with color characters that reduce readability.